### PR TITLE
Add batched queries

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -45,6 +46,61 @@ func UnmarshalSpec(id graphql.ID, v interface{}) error {
 
 type Handler struct {
 	Schema *graphql.Schema
+}
+
+type BatchedHandler struct {
+	Schema *graphql.Schema
+}
+
+type RequestData struct {
+	ID            string
+	Query         string                 `json:"query"`
+	Variables     map[string]interface{} `json:"variables"`
+	OperationName string                 `json:"operationName"`
+}
+
+type BatchedResponse struct {
+	ID string `json:"id"`
+	graphql.Response
+}
+
+func (h *BatchedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	queryBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var responses []*BatchedResponse
+	var queries []*RequestData
+	err = json.Unmarshal(queryBytes, &queries)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	responsesChan := make(chan *BatchedResponse, len(queries))
+	for i := range queries {
+		qr := queries[i]
+		go func(query *RequestData, responsesChan chan *BatchedResponse) {
+			gqlResponse := h.Schema.Exec(r.Context(), query.Query, query.OperationName, query.Variables)
+			responsesChan <- &BatchedResponse{query.ID, *gqlResponse}
+		}(qr, responsesChan)
+	}
+
+	for i := 0; i < len(queries); i++ {
+		responses = append(responses, <-responsesChan)
+	}
+	close(responsesChan)
+
+	responseJSON, err := json.Marshal(responses)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(responseJSON)
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -34,3 +34,27 @@ func TestServeHTTP(t *testing.T) {
 		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
 	}
 }
+
+func TestBatchedServeHTTP(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/some/path/here", strings.NewReader(`[{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null},
+	{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null}]`))
+	h := relay.BatchedHandler{Schema: starwarsSchema}
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d.", w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Fatalf("Invalid content-type. Expected [application/json], but instead got [%s]", contentType)
+	}
+
+	expectedResponse := `[{"id":"qID","data":{"hero":{"name":"R2-D2"}}},{"id":"qID","data":{"hero":{"name":"R2-D2"}}}]`
+	actualResponse := w.Body.String()
+	if expectedResponse != actualResponse {
+		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
+	}
+}


### PR DESCRIPTION
It adds handler for batched requests. They represent array of requests, and we return array of responses each with the corresponding ID.