### PR TITLE
Add possibility to limit max parallel queries while batch processing

### DIFF
--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -36,25 +36,50 @@ func TestServeHTTP(t *testing.T) {
 }
 
 func TestBatchedServeHTTP(t *testing.T) {
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("POST", "/some/path/here", strings.NewReader(`[{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null},
+	t.Run("no parallel queries limit", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/some/path/here", strings.NewReader(`[{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null},
 	{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null}]`))
-	h := relay.BatchedHandler{Schema: starwarsSchema}
+		h := relay.BatchedHandler{Schema: starwarsSchema}
 
-	h.ServeHTTP(w, r)
+		h.ServeHTTP(w, r)
 
-	if w.Code != 200 {
-		t.Fatalf("Expected status code 200, got %d.", w.Code)
-	}
+		if w.Code != 200 {
+			t.Fatalf("Expected status code 200, got %d.", w.Code)
+		}
 
-	contentType := w.Header().Get("Content-Type")
-	if contentType != "application/json" {
-		t.Fatalf("Invalid content-type. Expected [application/json], but instead got [%s]", contentType)
-	}
+		contentType := w.Header().Get("Content-Type")
+		if contentType != "application/json" {
+			t.Fatalf("Invalid content-type. Expected [application/json], but instead got [%s]", contentType)
+		}
 
-	expectedResponse := `[{"id":"qID","data":{"hero":{"name":"R2-D2"}}},{"id":"qID","data":{"hero":{"name":"R2-D2"}}}]`
-	actualResponse := w.Body.String()
-	if expectedResponse != actualResponse {
-		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
-	}
+		expectedResponse := `[{"id":"qID","data":{"hero":{"name":"R2-D2"}}},{"id":"qID","data":{"hero":{"name":"R2-D2"}}}]`
+		actualResponse := w.Body.String()
+		if expectedResponse != actualResponse {
+			t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
+		}
+	})
+	t.Run("with parallel queries limit", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/some/path/here", strings.NewReader(`[{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null},
+	{"id":"qID", "query":"{ hero { name } }", "operationName":"", "variables": null}]`))
+		h := relay.BatchedHandler{Schema: starwarsSchema, MaxParallelQueries: 1}
+
+		h.ServeHTTP(w, r)
+
+		if w.Code != 200 {
+			t.Fatalf("Expected status code 200, got %d.", w.Code)
+		}
+
+		contentType := w.Header().Get("Content-Type")
+		if contentType != "application/json" {
+			t.Fatalf("Invalid content-type. Expected [application/json], but instead got [%s]", contentType)
+		}
+
+		expectedResponse := `[{"id":"qID","data":{"hero":{"name":"R2-D2"}}},{"id":"qID","data":{"hero":{"name":"R2-D2"}}}]`
+		actualResponse := w.Body.String()
+		if expectedResponse != actualResponse {
+			t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
+		}
+	})
 }


### PR DESCRIPTION
If user initiates `BatchedHandler` with `MaxParallelQueries` >0 then this value is used as a max limit for parallel queries processing.